### PR TITLE
修复部分歌曲唱片和mp3文件依然使用http://的问题

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -3,6 +3,13 @@ import { defaultLimit } from '@/config'
 
 axios.defaults.baseURL = process.env.VUE_APP_BASE_API_URL
 
+// 添加拦截器，强制将所有http:// 转成 https://
+axios.interceptors.response.use(res => {
+  let data = JSON.stringify(res.data)
+  data = data.replace(/http:\/\//g, 'https://')
+  res.data = JSON.parse(data)
+})
+
 // 排行榜列表
 export function getToplistDetail() {
   return axios.get('/toplist/detail')


### PR DESCRIPTION
使用axios 拦截器将所有api中的http:// 替换成https:// 

抱歉，应当在最后加上return res 之前没注意😢